### PR TITLE
Adjust eye dimensions

### DIFF
--- a/src/emo_eyes/emo_eyes.ino
+++ b/src/emo_eyes/emo_eyes.ino
@@ -20,9 +20,8 @@ Arduino_GFX *gfx = new Arduino_GC9A01(bus, TFT_RST, 0 /* rotation */, true /* IP
 // Eye geometry and colors.
 static constexpr uint16_t COLOR_BACKGROUND = 0x0000; // Black
 static constexpr uint16_t COLOR_EYE = 0x07FF;        // Cyan
-static constexpr int16_t EYE_SIZE = 80;
-static constexpr int16_t EYE_WIDTH = EYE_SIZE;
-static constexpr int16_t EYE_HEIGHT = EYE_SIZE;
+static constexpr int16_t EYE_WIDTH = 60;
+static constexpr int16_t EYE_HEIGHT = 80;
 static constexpr int16_t EYE_PADDING = 10;
 static constexpr int16_t EYE_CORNER_RADIUS = 10;
 


### PR DESCRIPTION
## Summary
- set the eye width to 60 pixels and height to 80 pixels while keeping the rounded corner radius at 10
- rely on existing rendering logic to apply the updated dimensions during drawing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6934b02c8832699643e98ee0dbeff